### PR TITLE
Fix black flickering

### DIFF
--- a/MonoGame.Framework.WpfInterop/D3D11Host.cs
+++ b/MonoGame.Framework.WpfInterop/D3D11Host.cs
@@ -71,7 +71,6 @@ namespace MonoGame.Framework.WpfInterop
 
         private bool _resetBackBuffer, _dpiChanged;
         private bool _isActive;
-        private SpriteBatch _spriteBatch;
         private double _dpiScalingFactor = 1;
         private static bool _useASingleSharedGraphicsDevice = false;
         private List<IDisposable> _toBeDisposedNextFrame = new List<IDisposable>();
@@ -241,11 +240,6 @@ namespace MonoGame.Framework.WpfInterop
             _disposed = true;
             Activated = null;
             Deactivated = null;
-            if (_spriteBatch != null)
-            {
-                _spriteBatch.Dispose();
-                _spriteBatch = null;
-            }
             Dispose(true);
         }
 
@@ -456,7 +450,6 @@ namespace MonoGame.Framework.WpfInterop
             _d3D11Image.IsFrontBufferAvailableChanged += OnIsFrontBufferAvailableChanged;
             CreateBackBuffer();
             Source = _d3D11Image;
-            _spriteBatch = new SpriteBatch(GraphicsDevice);
         }
 
         private void OnIsFrontBufferAvailableChanged(object sender, DependencyPropertyChangedEventArgs eventArgs)

--- a/MonoGame.Framework.WpfInterop/D3D11Host.cs
+++ b/MonoGame.Framework.WpfInterop/D3D11Host.cs
@@ -204,7 +204,7 @@ namespace MonoGame.Framework.WpfInterop
         /// <summary>
         /// Gets the inner SharpDX graphics device context.
         /// </summary>
-        public DeviceContext InnerGraphicsDeviceContext => UseASingleSharedGraphicsDevice ? _staticInnerGraphicsDeviceContext : _innerGraphicsDeviceContext;
+        private DeviceContext InnerGraphicsDeviceContext => UseASingleSharedGraphicsDevice ? _staticInnerGraphicsDeviceContext : _innerGraphicsDeviceContext;
 
         /// <summary>
         /// Default services collection.

--- a/MonoGame.Framework.WpfInterop/Internals/D3D11Image.cs
+++ b/MonoGame.Framework.WpfInterop/Internals/D3D11Image.cs
@@ -102,7 +102,7 @@ namespace MonoGame.Framework.WpfInterop.Internals
                 using (Surface surface = _backBuffer.GetSurfaceLevel(0))
                 {
                     Lock();
-                    SetBackBuffer(D3DResourceType.IDirect3DSurface9, surface.NativePointer);
+                    SetBackBuffer(D3DResourceType.IDirect3DSurface9, surface.NativePointer, true);
                     Unlock();
                 }
             }
@@ -110,7 +110,7 @@ namespace MonoGame.Framework.WpfInterop.Internals
             {
                 // Reset back buffer.
                 Lock();
-                SetBackBuffer(D3DResourceType.IDirect3DSurface9, IntPtr.Zero);
+                SetBackBuffer(D3DResourceType.IDirect3DSurface9, IntPtr.Zero, true);
                 Unlock();
             }
 

--- a/global.json
+++ b/global.json
@@ -1,5 +1,7 @@
 {
   "sdk": {
-    "version": "5.0.100"
+    "version": "5.0",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
   }
 }


### PR DESCRIPTION
Please have a look at this approach. If there is a better way to fix the issue, I could not find it.

See #27 for more details and explanations.

Fix is achieved by accessing the inner SharpDX graphics context and the inner resources of the render targets. Then this happens:

1. cached render target is drawn into cached target without MSAA
2.  contents of cached render target are copied over to shared render target
3. when ready, lock is called and content is copied to the front buffer

This has two major indications:

+ performance considerations: previous rendering was async - copy to front buffer happened, even when flush was not done yet
+ now `ResolveSubresource` waits for flush to finish (as far as I understood it)
+ one more draw/copy to get MSAA working (draw rendering with MSAA to target without MSAA, copy over to shared target)

Please let me know what you think.

Cheers,
Georg