### PR TITLE
Restrict presented keys to value XNA key enum values.

### DIFF
--- a/MonoGame.Framework.WpfInterop/Input/WpfKeyboard.cs
+++ b/MonoGame.Framework.WpfInterop/Input/WpfKeyboard.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Windows;
+using System.Linq;
 
 namespace MonoGame.Framework.WpfInterop.Input
 {
@@ -17,6 +18,9 @@ namespace MonoGame.Framework.WpfInterop.Input
         #region Fields
 
         private readonly WpfGame _focusElement;
+
+        //ToHasSet<T> is not available in .NET 4.5.2
+        private static HashSet<int> XNAKeys = new HashSet<int>(Enum.GetValues(typeof(Keys)).Cast<int>());
 
         #endregion
 
@@ -87,7 +91,7 @@ namespace MonoGame.Framework.WpfInterop.Input
 
                         //This is just for a short demo, you may want this to return
                         //multiple keys!
-                        if (key != 0)
+                        if (key != 0 && XNAKeys.Contains(i))
                             pressedKeys.Add((Keys)i);
                     }
                 }


### PR DESCRIPTION
**Problem:** Invalid Key states being raised via the WpfKeyboard class's GetState function.

**Steps to replicate:** Press Win + Shift + S (Win 10/11 screen clip hotkey), other combination keys in Windows like Ctrl + Alt + Del also leverage virtual keys and cause the issue.
![image](https://user-images.githubusercontent.com/1655924/139508966-2d49d7b6-e505-4193-bdc1-1de78b83cdd4.png)

**Context:**
`GetKeyboardState` from user32.dll returns all valid virtual keys from Windows. XNA supports a limited subset of these keys through it's input mechanism, exposed via the `Microsoft.Xna.Framework.Input.Keys` public enum.

Under the hood an enum is just a struct, in the case of Keys, it uses the defaulting backing of an int. This means that you can cast any int to an enum backed by an int, even if the enum doesn't contain the respective value. The "value" of the enum doesn't correspond to any of it's compile time constants.

This predicament occurs with the following statement `pressedKeys.Add((Keys)i);`

Solution: 
* Store a list of all XNA keys and discard any system keys that XNA does not understand. 
* A hashset is used for trivial lookup times.
* The lookup is placed after pressed check to take advantage of short-circuit condition checking