### PR TITLE
update to net 6.. all seems to work .. added a x64 config.. left cor asANY cpu in case there is ARM windows support.. 

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,36 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-mgcb": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb"
+      ]
+    },
+    "dotnet-mgcb-editor": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor"
+      ]
+    },
+    "dotnet-mgcb-editor-linux": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-linux"
+      ]
+    },
+    "dotnet-mgcb-editor-windows": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-windows"
+      ]
+    },
+    "dotnet-mgcb-editor-mac": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-mac"
+      ]
+    }
+  }
+}

--- a/MonoGame.Framework.WpfInterop.sln
+++ b/MonoGame.Framework.WpfInterop.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31025.218
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32728.150
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WpfTest", "WpfTest\WpfTest.csproj", "{47B74078-7603-4364-9E22-DE6FC395EBB8}"
 EndProject
@@ -14,43 +14,60 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{47B74078-7603-4364-9E22-DE6FC395EBB8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{47B74078-7603-4364-9E22-DE6FC395EBB8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{47B74078-7603-4364-9E22-DE6FC395EBB8}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{47B74078-7603-4364-9E22-DE6FC395EBB8}.Debug|x86.Build.0 = Debug|Any CPU
-		{47B74078-7603-4364-9E22-DE6FC395EBB8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{47B74078-7603-4364-9E22-DE6FC395EBB8}.Release|Any CPU.Build.0 = Release|Any CPU
-		{47B74078-7603-4364-9E22-DE6FC395EBB8}.Release|x86.ActiveCfg = Release|Any CPU
-		{47B74078-7603-4364-9E22-DE6FC395EBB8}.Release|x86.Build.0 = Release|Any CPU
+		{47B74078-7603-4364-9E22-DE6FC395EBB8}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{47B74078-7603-4364-9E22-DE6FC395EBB8}.Debug|Any CPU.Build.0 = Debug|x86
+		{47B74078-7603-4364-9E22-DE6FC395EBB8}.Debug|x64.ActiveCfg = Debug|x64
+		{47B74078-7603-4364-9E22-DE6FC395EBB8}.Debug|x64.Build.0 = Debug|x64
+		{47B74078-7603-4364-9E22-DE6FC395EBB8}.Debug|x86.ActiveCfg = Debug|x86
+		{47B74078-7603-4364-9E22-DE6FC395EBB8}.Debug|x86.Build.0 = Debug|x86
+		{47B74078-7603-4364-9E22-DE6FC395EBB8}.Release|Any CPU.ActiveCfg = Release|x64
+		{47B74078-7603-4364-9E22-DE6FC395EBB8}.Release|Any CPU.Build.0 = Release|x64
+		{47B74078-7603-4364-9E22-DE6FC395EBB8}.Release|x64.ActiveCfg = Release|x64
+		{47B74078-7603-4364-9E22-DE6FC395EBB8}.Release|x64.Build.0 = Release|x64
+		{47B74078-7603-4364-9E22-DE6FC395EBB8}.Release|x86.ActiveCfg = Release|x86
+		{47B74078-7603-4364-9E22-DE6FC395EBB8}.Release|x86.Build.0 = Release|x86
 		{809F0D79-AEDC-4754-A213-FDBE97CCD6D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{809F0D79-AEDC-4754-A213-FDBE97CCD6D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{809F0D79-AEDC-4754-A213-FDBE97CCD6D6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{809F0D79-AEDC-4754-A213-FDBE97CCD6D6}.Debug|x64.Build.0 = Debug|Any CPU
 		{809F0D79-AEDC-4754-A213-FDBE97CCD6D6}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{809F0D79-AEDC-4754-A213-FDBE97CCD6D6}.Debug|x86.Build.0 = Debug|Any CPU
 		{809F0D79-AEDC-4754-A213-FDBE97CCD6D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{809F0D79-AEDC-4754-A213-FDBE97CCD6D6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{809F0D79-AEDC-4754-A213-FDBE97CCD6D6}.Release|x64.ActiveCfg = Release|Any CPU
+		{809F0D79-AEDC-4754-A213-FDBE97CCD6D6}.Release|x64.Build.0 = Release|Any CPU
 		{809F0D79-AEDC-4754-A213-FDBE97CCD6D6}.Release|x86.ActiveCfg = Release|Any CPU
 		{809F0D79-AEDC-4754-A213-FDBE97CCD6D6}.Release|x86.Build.0 = Release|Any CPU
-		{E9CAA688-D18B-47F1-99E1-716452738DC0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E9CAA688-D18B-47F1-99E1-716452738DC0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E9CAA688-D18B-47F1-99E1-716452738DC0}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{E9CAA688-D18B-47F1-99E1-716452738DC0}.Debug|x86.Build.0 = Debug|Any CPU
-		{E9CAA688-D18B-47F1-99E1-716452738DC0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E9CAA688-D18B-47F1-99E1-716452738DC0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E9CAA688-D18B-47F1-99E1-716452738DC0}.Release|x86.ActiveCfg = Release|Any CPU
-		{E9CAA688-D18B-47F1-99E1-716452738DC0}.Release|x86.Build.0 = Release|Any CPU
-		{E021F463-1BA4-4CF2-8900-D385FBC5746E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E021F463-1BA4-4CF2-8900-D385FBC5746E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E021F463-1BA4-4CF2-8900-D385FBC5746E}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{E021F463-1BA4-4CF2-8900-D385FBC5746E}.Debug|x86.Build.0 = Debug|Any CPU
-		{E021F463-1BA4-4CF2-8900-D385FBC5746E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E021F463-1BA4-4CF2-8900-D385FBC5746E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E021F463-1BA4-4CF2-8900-D385FBC5746E}.Release|x86.ActiveCfg = Release|Any CPU
-		{E021F463-1BA4-4CF2-8900-D385FBC5746E}.Release|x86.Build.0 = Release|Any CPU
+		{E9CAA688-D18B-47F1-99E1-716452738DC0}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{E9CAA688-D18B-47F1-99E1-716452738DC0}.Debug|Any CPU.Build.0 = Debug|x86
+		{E9CAA688-D18B-47F1-99E1-716452738DC0}.Debug|x64.ActiveCfg = Debug|x64
+		{E9CAA688-D18B-47F1-99E1-716452738DC0}.Debug|x64.Build.0 = Debug|x64
+		{E9CAA688-D18B-47F1-99E1-716452738DC0}.Debug|x86.ActiveCfg = Debug|x86
+		{E9CAA688-D18B-47F1-99E1-716452738DC0}.Debug|x86.Build.0 = Debug|x86
+		{E9CAA688-D18B-47F1-99E1-716452738DC0}.Release|Any CPU.ActiveCfg = Release|x64
+		{E9CAA688-D18B-47F1-99E1-716452738DC0}.Release|Any CPU.Build.0 = Release|x64
+		{E9CAA688-D18B-47F1-99E1-716452738DC0}.Release|x64.ActiveCfg = Release|x64
+		{E9CAA688-D18B-47F1-99E1-716452738DC0}.Release|x64.Build.0 = Release|x64
+		{E9CAA688-D18B-47F1-99E1-716452738DC0}.Release|x86.ActiveCfg = Release|x86
+		{E9CAA688-D18B-47F1-99E1-716452738DC0}.Release|x86.Build.0 = Release|x86
+		{E021F463-1BA4-4CF2-8900-D385FBC5746E}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{E021F463-1BA4-4CF2-8900-D385FBC5746E}.Debug|Any CPU.Build.0 = Debug|x86
+		{E021F463-1BA4-4CF2-8900-D385FBC5746E}.Debug|x64.ActiveCfg = Debug|x64
+		{E021F463-1BA4-4CF2-8900-D385FBC5746E}.Debug|x64.Build.0 = Debug|x64
+		{E021F463-1BA4-4CF2-8900-D385FBC5746E}.Debug|x86.ActiveCfg = Debug|x86
+		{E021F463-1BA4-4CF2-8900-D385FBC5746E}.Release|Any CPU.ActiveCfg = Release|x64
+		{E021F463-1BA4-4CF2-8900-D385FBC5746E}.Release|Any CPU.Build.0 = Release|x64
+		{E021F463-1BA4-4CF2-8900-D385FBC5746E}.Release|x64.ActiveCfg = Release|x64
+		{E021F463-1BA4-4CF2-8900-D385FBC5746E}.Release|x64.Build.0 = Release|x64
+		{E021F463-1BA4-4CF2-8900-D385FBC5746E}.Release|x86.ActiveCfg = Release|x86
+		{E021F463-1BA4-4CF2-8900-D385FBC5746E}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MonoGame.Framework.WpfInterop/MonoGame.Framework.WpfInterop.csproj
+++ b/MonoGame.Framework.WpfInterop/MonoGame.Framework.WpfInterop.csproj
@@ -1,19 +1,20 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net452</TargetFrameworks>
+    <TargetFrameworks>net6-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <PackageId>MonoGame.Framework.WpfInterop</PackageId>
-    <Version>1.9.1</Version>
+    <Version>2.1</Version>
     <Authors>MarcStan</Authors>
     <Description>MonoGame integration with WPF. This package provides the D3D11Host from the MonoGame WpfInteropSample. It extends it with WpfGame, WpfMouse and WpfKeyboard and makes it actually usable in any WPF application.
 
-Supports .Net 4.5.2, .Net Core 3.1 and .Net 5</Description>
-    <Copyright>Copyright MarcStan 2016 - 2021</Copyright>
+Supports .Net 6 windows only x64 and x86 for now, windows ARM mabye in future</Description>
+    <Copyright>Copyright MarcStan 2016 - 2022</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/MarcStan/monogame-framework-wpfinterop</PackageProjectUrl>
     <PackageTags>monogame wpf interop</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
@@ -21,7 +22,7 @@ Supports .Net 4.5.2, .Net Core 3.1 and .Net 5</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.0.1641" />
+	  <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.1.303"></PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/WpfTest.Core/WpfTest.Core.csproj
+++ b/WpfTest.Core/WpfTest.Core.csproj
@@ -1,14 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
+	 <Platforms>x86;x64</Platforms>
     <UseWPF>true</UseWPF>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ContentTargetFolders>content</ContentTargetFolders>
+
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.0.1641" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.0.1641" />
+    <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.1.303" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MonoGame.Framework.WpfInterop\MonoGame.Framework.WpfInterop.csproj" />

--- a/WpfTest.Core5/WpfTest.Core5.csproj
+++ b/WpfTest.Core5/WpfTest.Core5.csproj
@@ -1,10 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ContentTargetFolders>content</ContentTargetFolders>
+    <Platforms>x64;x86;</Platforms>
+    <StartupObject>WpfTest.App</StartupObject>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Content\Content.mgcb" />
@@ -42,8 +44,8 @@
     <Compile Include="..\WpfTest.Core\Views\TextInputWindow.xaml.cs" Link="Views\TextInputWindow.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.0.1641" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.0.1641" />
+    <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.1.303" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MonoGame.Framework.WpfInterop\MonoGame.Framework.WpfInterop.csproj" />

--- a/WpfTest/WpfTest.csproj
+++ b/WpfTest/WpfTest.csproj
@@ -1,14 +1,17 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ContentTargetFolders>content</ContentTargetFolders>
+    <Platforms>x86;x64</Platforms>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.0.1641" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.0.1641" />
+    <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.1.303" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MonoGame.Framework.WpfInterop\MonoGame.Framework.WpfInterop.csproj" />


### PR DESCRIPTION
… as any cpu in case ARM windows gets supported..


This is not a formal PR  I did not read the guidelines but this might save yhou time if yhou need to do this ive been at this stuff over a week and its not fun.


im submitting this if you completely ignore it ,  its fine with me, because there is flux everywhere, Silk to consider, and breaking changes moving to 3.81 monogame.  i just need to see if it works in myh setup, because im using 
https://github.com/craftworkgames/MonoGame.WpfCore, and having too many issues some of which yhou have addressed


..  I don't frankly know if it should be updated or stay as a fork or renamed.
Sorry for the typos,  I'm so overwhelmed by updateing to latest stuff (it's worth it because of the perfromance is even better when non graphic core dlls are moved from netstandard to net6 libs), at least out of the WPF context.. but Mg 3.8 -> 3.81 drops netstandard and 4.8 and therefor is very hard.

upgrade assistant could not do anything with this one.

as for the changes, they are minor:

not sure if all the config is simple as possible, could by anycpu but got warningins about arm...it all works.   on win 64 , at least quck tests.   the problem is, i dont use the GameComponent, i prefer teh other way used in the MGcontent control and I dont use the game class , except in my game core.    in fact ,its and abstration well out of favor with most of the frameworks build over MG.. 



this one juse use the Device but has none of the workarounds and fixes yhou put in for tabbed windows and multisampling  .. its not needed to have a game class, and in my use case i handle input via WPF. in the level editor, and touch separately since im using it to edit not play.. ..  i was using the MGcontent control but it lacked all the workarounds and thiings in here for tabbed devices, i put in my own fixes but now i cant get it to work on net 6 wpf.   so i might try this or try to factor out the game refs to juse device service. or its not a trivial merge.. also there is a https://github.com/microsoft/WPFDXInterop which hasnt been update in ages.. i dont know if im going to move to avalonia or maui or Mrya or something based on monogame but i have years invested in legacy wpf editor, and its working on wiondows...

 I would love if thsi stuff woks on ARM surface go I can develop androids apps on one, using vs 2022 arm surface with touch an DX ( or better windows GL and then SDL , or silk) , but targeting android if that is ... right now im wating for this to pan out.. not sure if this is a worth PR and i bumped the version to 2 because its not netstand 2.0 compatible, its doenst work on .48  , and lots of legacy code will break if updating to MG 3.81.  so i got through it and mhy framerate is faster so it was worth updateing all my cores to net6 libs...even if wpf netcore6 only works on windows 64 and maybe 32.   theres commnets taht 32 bit builds are acutally faster... in manyh situations so i left it in.  anyways if you dont care to merge , i wont be offended.. i just need to try to get this back in my tool somehow, mabye ill merge some of your approach with the Wpfcontent control by craftwork games.  ( i updated his sample but that works on ly in a simple app no tabs)   i get an GetSharedHandle error creating render target im stuck there.   anways hope this helps mabye it could be a branch..     
 
 
 